### PR TITLE
Fix space bar not inserting space

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,14 +55,26 @@
             this.remove()
         });
 
-        // Prevent the page from scrolling when the spacebar is pressed.
-        // This mainly affects Safari on iPad with an external keyboard, where the browser
-        // treats the <space> key as a PageUp/PageDown command if the body element owns the
-        // focus. By calling preventDefault() we allow the TIC-80 runtime to receive the
-        // key event and insert a space in the code editor instead.
+        // Prevent the page from scrolling when the spacebar is pressed, but still forward the
+        // event to the TIC-80 runtime so that a space character is inserted in the editor.
         document.addEventListener('keydown', function (event) {
             if (event.code === 'Space' && document.activeElement === document.body) {
+                // Stop the browser from scrolling the page.
                 event.preventDefault();
+
+                // Re-emit a synthetic "keypress" event so that the TIC-80 runtime receives the
+                // printable space character it expects.  This mirrors a regular keypress where
+                // key === " " and charCode === 32.
+                const keypress = new KeyboardEvent('keypress', {
+                    key: ' ',
+                    code: 'Space',
+                    charCode: 32,
+                    keyCode: 32,
+                    which: 32,
+                    bubbles: true,
+                    cancelable: true
+                });
+                document.dispatchEvent(keypress);
             }
         }, { capture: true });
     </script>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Re-enable space character insertion when the spacebar is pressed by dispatching a synthetic keypress event, while maintaining page scroll prevention.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e0c0549-3e9f-4a3c-a6af-9d0a02768c9b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e0c0549-3e9f-4a3c-a6af-9d0a02768c9b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>