### PR TITLE
Fix tic-80 editor scaling for all devices

### DIFF
--- a/export.html
+++ b/export.html
@@ -28,11 +28,40 @@
 
         </div>
 
-        <canvas style="width: 100%; height: 100%; margin: 0 auto; display: block; image-rendering: pixelated;" id="canvas" oncontextmenu="event.preventDefault()" onmousedown="window.focus()"></canvas>
+        <canvas style="width: 100%; /* height: 100%; */ margin: 0 auto; display: block; image-rendering: pixelated;" id="canvas" oncontextmenu="event.preventDefault()" onmousedown="window.focus()"></canvas>
     </div>
 
     <script type="text/javascript">
         var Module = {canvas: document.getElementById('canvas'), arguments:['cart.tic']}
+
+        // --- NEW: Dynamically resize the TIC-80 canvas to maintain aspect ratio ---
+        (function () {
+            const ASPECT = 240 / 136; // TIC-80 internal resolution aspect ratio (~16:9)
+            const canvas    = Module.canvas;
+            const container = canvas.parentElement; // the ".game" wrapper
+
+            function resize() {
+                const availW = container.clientWidth;
+                const availH = container.clientHeight;
+
+                let newW = availW;
+                let newH = newW / ASPECT;
+                if (newH > availH) {
+                    newH = availH;
+                    newW = newH * ASPECT;
+                }
+
+                canvas.style.width  = newW + 'px';
+                canvas.style.height = newH + 'px';
+                canvas.style.position = 'absolute';
+                canvas.style.left = ((availW - newW) / 2) + 'px';
+                canvas.style.top  = ((availH - newH) / 2) + 'px';
+            }
+
+            resize();
+            window.addEventListener('resize', resize);
+            window.addEventListener('orientationchange', resize);
+        })();
 
         const gameFrame = document.getElementById('game-frame')
         const displayStyle = window.getComputedStyle(gameFrame).display;

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
         </div>
 
-        <canvas style="width: 100%; height: 100%; margin: 0 auto; display: block; image-rendering: pixelated;" id="canvas" oncontextmenu="event.preventDefault()" onmousedown="window.focus()"></canvas>
+        <canvas style="width: 100%; /* height: 100%; */ margin: 0 auto; display: block; image-rendering: pixelated;" id="canvas" oncontextmenu="event.preventDefault()" onmousedown="window.focus()"></canvas>
     </div>
 
     <div id="add-modal" class="modal">
@@ -77,6 +77,38 @@
                 document.dispatchEvent(keypress);
             }
         }, { capture: true });
+
+        // --- NEW: Dynamically resize the TIC-80 canvas to keep its 240×136 aspect ratio ---
+        (function () {
+            const ASPECT = 240 / 136; // TIC-80 internal resolution aspect ratio (~16:9)
+            const canvas   = Module.canvas;
+            const container = canvas.parentElement; // the ".game" wrapper
+
+            function resize() {
+                const availW = container.clientWidth;
+                const availH = container.clientHeight;
+
+                // Compute the largest size that fits while preserving aspect ratio
+                let newW = availW;
+                let newH = newW / ASPECT;
+                if (newH > availH) {
+                    newH = availH;
+                    newW = newH * ASPECT;
+                }
+
+                // Apply size & centre the canvas
+                canvas.style.width  = newW + 'px';
+                canvas.style.height = newH + 'px';
+                canvas.style.position = 'absolute';
+                canvas.style.left = ((availW - newW) / 2) + 'px';
+                canvas.style.top  = ((availH - newH) / 2) + 'px';
+            }
+
+            // Initial call and bind events
+            resize();
+            window.addEventListener('resize', resize);
+            window.addEventListener('orientationchange', resize);
+        })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Dynamically resize the TIC-80 canvas to maintain its aspect ratio and fit the viewport, fixing scaling issues on mobile devices.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous `height: 100%` style on the canvas caused it to stretch or shrink disproportionately, resulting in squashed views or large padding gaps on various screen sizes, particularly on phones and tablets. The new JavaScript ensures the canvas always maintains its native 240x136 aspect ratio while occupying the largest possible area within its container, centered horizontally and vertically.

---
<a href="https://cursor.com/background-agent?bcId=bc-3349a6e8-d186-45f7-af08-629c67785fc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3349a6e8-d186-45f7-af08-629c67785fc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>